### PR TITLE
add react-loadable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "postcss-import": "10.0.0",
     "postcss-loader": "1.3.3",
     "postcss-url": "7.0.0",
+    "react-loadable": "5.3.1",
     "rimraf": "2.6.2",
     "style-loader": "0.19.0",
     "stylelint": "8.2.0",


### PR DESCRIPTION
Added `react-loadable` as a dependency to package.json to fix`npm start` error:
```
ERROR in ./server/index.js
Module build failed: ReferenceError: Unknown plugin "react-loadable/babel" specified in "<path>/.babelrc"
```